### PR TITLE
Trilinos Random Failure Tool Patch 2024-02-15

### DIFF
--- a/test/ci_support/cdash_analyze_and_report_random_failures_UnitTests.py
+++ b/test/ci_support/cdash_analyze_and_report_random_failures_UnitTests.py
@@ -229,7 +229,9 @@ class test_cdash_analyze_and_report_random_failures(unittest.TestCase):
 
     # Test to no random failure case starting from two initial failing tests (ift).
     # Each ift has a test history containing multiple tests with passing and nonpassing results,
-    # but non share the same sha1 pair.
+    # but non share the same sha1 pair. This also tests the --email-subject-prefix argument
+    # and checks if it's present in the html page title, which is also used in the email subject
+    # line.
     #
     def test_no_random_failure(self):
 
@@ -247,7 +249,7 @@ class test_cdash_analyze_and_report_random_failures(unittest.TestCase):
                 "PASSED \(rft=0, ift=2\): Project Name Group Name on 2018-10-26 to 2018-10-28"
             ],
             htmlFileRegexList=[
-                "<h2>PASSED \(rft=0, ift=2\): Project Name Group Name on 2018-10-26 to 2018-10-28</h2>",
+                "<h2>Subject Prefix PASSED \(rft=0, ift=2\): Project Name Group Name on 2018-10-26 to 2018-10-28</h2>",
 
                 "<h2>Random test failure scan results for Project Name from 2018-10-26 to 2018-10-28</h2>",
 
@@ -260,7 +262,8 @@ class test_cdash_analyze_and_report_random_failures(unittest.TestCase):
                 "</p>"
             ],
             extraCmndLineOptionsList=[
-                "--days-of-history=3"
+                "--days-of-history=3",
+                "--email-subject-prefix='Subject Prefix '"
             ]
         )
 

--- a/tribits/ci_support/CDashAnalyzeReportRandomFailures.py
+++ b/tribits/ci_support/CDashAnalyzeReportRandomFailures.py
@@ -32,6 +32,7 @@ class CDashAnalyzeReportRandomFailuresDriver:
     writeEmailToFile = self.args.write_email_to_file
     sendEmailFrom = self.args.send_email_from
     sendEmailTo = self.args.send_email_to
+    emailSubjectPrefix = self.args.email_subject_prefix
 
     randomFailureSummaries = []
 
@@ -231,11 +232,12 @@ class CDashAnalyzeReportRandomFailuresDriver:
     cdashReportData.htmlEmailBodyTop += "\n</p>"
 
     defaultPageStyle = CDQAR.getDefaultHtmlPageStyleStr()
+    subjectLine = emailSubjectPrefix+summaryLine
 
     if writeEmailToFile:
       print("\nWriting HTML to file: "+writeEmailToFile+" ...")
       htmlStr = CDQAR.getFullCDashHtmlReportPageStr(cdashReportData,
-        pageTitle=summaryLine, pageStyle=defaultPageStyle)
+        pageTitle=subjectLine, pageStyle=defaultPageStyle)
       # print(htmlStr)
       with open(writeEmailToFile, 'w') as outFile:
         outFile.write(htmlStr)
@@ -247,7 +249,7 @@ class CDashAnalyzeReportRandomFailuresDriver:
         emailAddress = emailAddress.strip()
         print("\nSending email to '"+emailAddress+"' ...")
         msg=CDQAR.createHtmlMimeEmail(
-          sendEmailFrom, emailAddress, summaryLine, "", htmlStr)
+          sendEmailFrom, emailAddress, subjectLine, "", htmlStr)
         CDQAR.sendMineEmail(msg)
 
   def getCmndLineArgs(self):
@@ -290,6 +292,9 @@ class CDashAnalyzeReportRandomFailuresDriver:
     parser.add_argument("--send-email-from", default="random-failure-script@noreply.org",
       help="Addressed sender of the script summary results email."+\
         " [default='random-failure-script@noreply.org']")
+    parser.add_argument("--email-subject-prefix", default="",
+      help="Prefix string added to the email subject line."+\
+        " [default='']")
 
     self.args = parser.parse_args()
 


### PR DESCRIPTION
- Added optional `--email-subject-prefix` argument to add a prefix string to html page title and email subject line
- Change test history url output in summary report to use a hyperlink to clean up output (this was already push to the `trilinos-random-failure-tool` branch, but is also included in this patch) 